### PR TITLE
Allow access to Wayland socket

### DIFF
--- a/org.godotengine.GodotSharp.yaml
+++ b/org.godotengine.GodotSharp.yaml
@@ -60,6 +60,7 @@ build-options:
       udev=no
 finish-args:
   - --share=ipc
+  - --socket=wayland
   - --socket=x11
   - --share=network
   - --socket=pulseaudio


### PR DESCRIPTION
Godot 4.3 adds opt-in Wayland support. To use this, the Wayland socket
is of course needed.

--socket=x11 is left as-is rather than being replaced with fallback-x11
because X11 remains the default; manual intervention is needed to
configure the editor and/or game to use Wayland.

(cherry picked from commit 673564087d94ab47611628d731cf55f617b6406d on
org.godotengine.Godot//beta, from
https://github.com/flathub/org.godotengine.Godot/pull/170)
