### PR TITLE
Remove unused SCons options

### DIFF
--- a/org.godotengine.GodotSharp.yaml
+++ b/org.godotengine.GodotSharp.yaml
@@ -41,8 +41,6 @@ build-options:
     SCONS_FLAGS: >
       platform=linuxbsd
       CCFLAGS=-I/app/include
-      prefix=/app
-      unix_global_settings_path=/app
       progress=no
       builtin_freetype=no
       builtin_graphite=no


### PR DESCRIPTION
- GodotSharp counterpart of https://github.com/flathub/org.godotengine.Godot/pull/190.

These options are not present anywhere in 4.3's source code.
