### PR TITLE
Prevent duplicates from appearing in nuget-sources.json.

### DIFF
--- a/generate_sources.py
+++ b/generate_sources.py
@@ -41,13 +41,16 @@ def main():
                 url = 'https://api.nuget.org/v3-flatcontainer/{}/{}/{}'.format(name, version, filename)
                 with path.open() as fp:
                     sha512 = binascii.hexlify(base64.b64decode(fp.read())).decode('ascii')
-                    sources.append({
-                        'type': 'file',
-                        'url': url,
-                        'sha512': sha512,
-                        'dest': "nuget-sources",
-                        'dest-filename': filename,
-                    })
+                    source = {
+                         'type': 'file',
+                         'url': url,
+                         'sha512': sha512,
+                         'dest': "nuget-sources",
+                         'dest-filename': filename,
+                    }
+                    # Prevent duplicates by only adding source if not already in sources list.
+                    if( source not in sources ):
+                        sources.append(source)
 
     # Save the sources into a JSON file
     with open('nuget/nuget-sources.json', 'w') as fp:


### PR DESCRIPTION
I'm taking a look at figuring out what's wrong with updating this flatpak, and while I was looking around I noticed that there were **lots** of identical duplicates within `nuget-sources.json`.

I know this won't compile because the current build of this project is broken, so this is more of a suggestion PR.